### PR TITLE
chore: bump package version to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winor30/mcp-server-datadog",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "MCP server for interacting with Datadog API",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Increment package version to reflect recent feature additions and improvements to the Datadog server integration, specifically the new downtimes tool functionality introduced in the previous commit.
