### PR TITLE
Datadog MCP: Add a 'get_all_services' tool with test coverage.

### DIFF
--- a/src/tools/logs/schema.ts
+++ b/src/tools/logs/schema.ts
@@ -21,7 +21,10 @@ export const GetLogsZodSchema = z.object({
  * @param limit - Optional. Maximum number of logs to search through. Default is 1000.
  */
 export const GetAllServicesZodSchema = z.object({
-  query: z.string().default('*').describe('Optional query filter for log search'),
+  query: z
+    .string()
+    .default('*')
+    .describe('Optional query filter for log search'),
   from: z.number().describe('Start time in epoch seconds'),
   to: z.number().describe('End time in epoch seconds'),
   limit: z

--- a/src/tools/logs/schema.ts
+++ b/src/tools/logs/schema.ts
@@ -10,3 +10,23 @@ export const GetLogsZodSchema = z.object({
     .default(100)
     .describe('Maximum number of logs to return. Default is 100.'),
 })
+
+/**
+ * Schema for retrieving all unique service names from logs.
+ * Defines parameters for querying logs within a time window.
+ *
+ * @param query - Optional. Additional query filter for log search. Defaults to "*" (all logs)
+ * @param from - Required. Start time in epoch seconds
+ * @param to - Required. End time in epoch seconds
+ * @param limit - Optional. Maximum number of logs to search through. Default is 1000.
+ */
+export const GetAllServicesZodSchema = z.object({
+  query: z.string().default('*').describe('Optional query filter for log search'),
+  from: z.number().describe('Start time in epoch seconds'),
+  to: z.number().describe('End time in epoch seconds'),
+  limit: z
+    .number()
+    .optional()
+    .default(1000)
+    .describe('Maximum number of logs to search through. Default is 1000.'),
+})

--- a/src/tools/logs/tool.ts
+++ b/src/tools/logs/tool.ts
@@ -57,7 +57,7 @@ export const createLogsToolHandlers = (
       ],
     }
   },
-  
+
   get_all_services: async (request) => {
     const { query, from, to, limit } = GetAllServicesZodSchema.parse(
       request.params.arguments,
@@ -84,7 +84,7 @@ export const createLogsToolHandlers = (
 
     // Extract unique services from logs
     const services = new Set<string>()
-    
+
     for (const log of response.data) {
       // Access service attribute from logs based on the Datadog API structure
       if (log.attributes && log.attributes.service) {

--- a/src/tools/logs/tool.ts
+++ b/src/tools/logs/tool.ts
@@ -1,9 +1,9 @@
 import { ExtendedTool, ToolHandlers } from '../../utils/types'
 import { v2 } from '@datadog/datadog-api-client'
 import { createToolSchema } from '../../utils/tool'
-import { GetLogsZodSchema } from './schema'
+import { GetLogsZodSchema, GetAllServicesZodSchema } from './schema'
 
-type LogsToolName = 'get_logs'
+type LogsToolName = 'get_logs' | 'get_all_services'
 type LogsTool = ExtendedTool<LogsToolName>
 
 export const LOGS_TOOLS: LogsTool[] = [
@@ -11,6 +11,11 @@ export const LOGS_TOOLS: LogsTool[] = [
     GetLogsZodSchema,
     'get_logs',
     'Search and retrieve logs from Datadog',
+  ),
+  createToolSchema(
+    GetAllServicesZodSchema,
+    'get_all_services',
+    'Extract all unique service names from logs',
   ),
 ] as const
 
@@ -48,6 +53,50 @@ export const createLogsToolHandlers = (
         {
           type: 'text',
           text: `Logs data: ${JSON.stringify(response.data)}`,
+        },
+      ],
+    }
+  },
+  
+  get_all_services: async (request) => {
+    const { query, from, to, limit } = GetAllServicesZodSchema.parse(
+      request.params.arguments,
+    )
+
+    const response = await apiInstance.listLogs({
+      body: {
+        filter: {
+          query,
+          // `from` and `to` are in epoch seconds, but the Datadog API expects milliseconds
+          from: `${from * 1000}`,
+          to: `${to * 1000}`,
+        },
+        page: {
+          limit,
+        },
+        sort: '-timestamp',
+      },
+    })
+
+    if (response.data == null) {
+      throw new Error('No logs data returned')
+    }
+
+    // Extract unique services from logs
+    const services = new Set<string>()
+    
+    for (const log of response.data) {
+      // Access service attribute from logs based on the Datadog API structure
+      if (log.attributes && log.attributes.service) {
+        services.add(log.attributes.service)
+      }
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Services: ${JSON.stringify(Array.from(services).sort())}`,
         },
       ],
     }

--- a/tests/tools/logs.test.ts
+++ b/tests/tools/logs.test.ts
@@ -264,17 +264,22 @@ describe('Logs Tool', () => {
         const response = (await toolHandlers.get_all_services(
           request,
         )) as unknown as DatadogToolResponse
-        
+
         expect(response.content[0].text).toContain('Services')
         // Check if response contains the expected services (sorted alphabetically)
         const expected = ['api-service', 'database-service', 'web-service']
-        expected.forEach(service => {
+        expected.forEach((service) => {
           expect(response.content[0].text).toContain(service)
         })
-        
+
         // Check that we've extracted unique services (no duplicates)
         const servicesText = response.content[0].text
-        const servicesJson = JSON.parse(servicesText.substring(servicesText.indexOf('['), servicesText.lastIndexOf(']') + 1))
+        const servicesJson = JSON.parse(
+          servicesText.substring(
+            servicesText.indexOf('['),
+            servicesText.lastIndexOf(']') + 1,
+          ),
+        )
         expect(servicesJson).toHaveLength(3) // Only 3 unique services, not 4
         expect(servicesJson).toEqual(expected)
       })()
@@ -327,13 +332,18 @@ describe('Logs Tool', () => {
         const response = (await toolHandlers.get_all_services(
           request,
         )) as unknown as DatadogToolResponse
-        
+
         expect(response.content[0].text).toContain('Services')
         expect(response.content[0].text).toContain('web-service')
-        
+
         // Ensure we only have one service (the one with a defined service attribute)
         const servicesText = response.content[0].text
-        const servicesJson = JSON.parse(servicesText.substring(servicesText.indexOf('['), servicesText.lastIndexOf(']') + 1))
+        const servicesJson = JSON.parse(
+          servicesText.substring(
+            servicesText.indexOf('['),
+            servicesText.lastIndexOf(']') + 1,
+          ),
+        )
         expect(servicesJson).toHaveLength(1)
       })()
 
@@ -362,7 +372,7 @@ describe('Logs Tool', () => {
         const response = (await toolHandlers.get_all_services(
           request,
         )) as unknown as DatadogToolResponse
-        
+
         expect(response.content[0].text).toContain('Services')
         expect(response.content[0].text).toContain('[]') // Empty array of services
       })()

--- a/tests/tools/logs.test.ts
+++ b/tests/tools/logs.test.ts
@@ -194,4 +194,180 @@ describe('Logs Tool', () => {
       server.close()
     })
   })
+
+  describe.concurrent('get_all_services', async () => {
+    it('should extract unique service names from logs', async () => {
+      // Mock API response with multiple services
+      const mockHandler = http.post(logsEndpoint, async () => {
+        return HttpResponse.json({
+          data: [
+            {
+              id: 'AAAAAXGLdD0AAABPV-5whqgB',
+              attributes: {
+                timestamp: 1640995199000,
+                status: 'info',
+                message: 'Test log message 1',
+                service: 'web-service',
+                tags: ['env:test'],
+              },
+              type: 'log',
+            },
+            {
+              id: 'AAAAAXGLdD0AAABPV-5whqgC',
+              attributes: {
+                timestamp: 1640995198000,
+                status: 'info',
+                message: 'Test log message 2',
+                service: 'api-service',
+                tags: ['env:test'],
+              },
+              type: 'log',
+            },
+            {
+              id: 'AAAAAXGLdD0AAABPV-5whqgD',
+              attributes: {
+                timestamp: 1640995197000,
+                status: 'info',
+                message: 'Test log message 3',
+                service: 'web-service', // Duplicate service to test uniqueness
+                tags: ['env:test'],
+              },
+              type: 'log',
+            },
+            {
+              id: 'AAAAAXGLdD0AAABPV-5whqgE',
+              attributes: {
+                timestamp: 1640995196000,
+                status: 'error',
+                message: 'Test error message',
+                service: 'database-service',
+                tags: ['env:test'],
+              },
+              type: 'log',
+            },
+          ],
+          meta: {
+            page: {},
+          },
+        })
+      })
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('get_all_services', {
+          query: '*',
+          from: 1640995100, // epoch seconds
+          to: 1640995200, // epoch seconds
+          limit: 100,
+        })
+        const response = (await toolHandlers.get_all_services(
+          request,
+        )) as unknown as DatadogToolResponse
+        
+        expect(response.content[0].text).toContain('Services')
+        // Check if response contains the expected services (sorted alphabetically)
+        const expected = ['api-service', 'database-service', 'web-service']
+        expected.forEach(service => {
+          expect(response.content[0].text).toContain(service)
+        })
+        
+        // Check that we've extracted unique services (no duplicates)
+        const servicesText = response.content[0].text
+        const servicesJson = JSON.parse(servicesText.substring(servicesText.indexOf('['), servicesText.lastIndexOf(']') + 1))
+        expect(servicesJson).toHaveLength(3) // Only 3 unique services, not 4
+        expect(servicesJson).toEqual(expected)
+      })()
+
+      server.close()
+    })
+
+    it('should handle logs with missing service attributes', async () => {
+      const mockHandler = http.post(logsEndpoint, async () => {
+        return HttpResponse.json({
+          data: [
+            {
+              id: 'AAAAAXGLdD0AAABPV-5whqgB',
+              attributes: {
+                timestamp: 1640995199000,
+                status: 'info',
+                message: 'Test log message 1',
+                service: 'web-service',
+                tags: ['env:test'],
+              },
+              type: 'log',
+            },
+            {
+              id: 'AAAAAXGLdD0AAABPV-5whqgC',
+              attributes: {
+                timestamp: 1640995198000,
+                status: 'info',
+                message: 'Test log message with no service',
+                // No service attribute
+                tags: ['env:test'],
+              },
+              type: 'log',
+            },
+          ],
+          meta: {
+            page: {},
+          },
+        })
+      })
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('get_all_services', {
+          query: '*',
+          from: 1640995100,
+          to: 1640995200,
+          limit: 100,
+        })
+        const response = (await toolHandlers.get_all_services(
+          request,
+        )) as unknown as DatadogToolResponse
+        
+        expect(response.content[0].text).toContain('Services')
+        expect(response.content[0].text).toContain('web-service')
+        
+        // Ensure we only have one service (the one with a defined service attribute)
+        const servicesText = response.content[0].text
+        const servicesJson = JSON.parse(servicesText.substring(servicesText.indexOf('['), servicesText.lastIndexOf(']') + 1))
+        expect(servicesJson).toHaveLength(1)
+      })()
+
+      server.close()
+    })
+
+    it('should handle empty response data', async () => {
+      const mockHandler = http.post(logsEndpoint, async () => {
+        return HttpResponse.json({
+          data: [],
+          meta: {
+            page: {},
+          },
+        })
+      })
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('get_all_services', {
+          query: 'service:non-existent',
+          from: 1640995100,
+          to: 1640995200,
+          limit: 100,
+        })
+        const response = (await toolHandlers.get_all_services(
+          request,
+        )) as unknown as DatadogToolResponse
+        
+        expect(response.content[0].text).toContain('Services')
+        expect(response.content[0].text).toContain('[]') // Empty array of services
+      })()
+
+      server.close()
+    })
+  })
 })


### PR DESCRIPTION
Returns a list of unique services found in the logs.

This is useful for an integration we're building at Icosic AI.

We're a startup based in San Francisco - our product is an AI site reliability engineer.

Check us out: https://icosic.com

By Zuri Obozuwa, Founder @ Icosic AI