### PR TITLE
metrics: change get_metrics to query_metrics

### DIFF
--- a/src/tools/metrics/schema.ts
+++ b/src/tools/metrics/schema.ts
@@ -1,11 +1,17 @@
 import { z } from 'zod'
 
-export const GetMetricsZodSchema = z.object({
-  from: z.number().describe('Start time in epoch seconds'),
-  to: z.number().describe('End time in epoch seconds'),
+export const QueryMetricsZodSchema = z.object({
+  from: z
+    .number()
+    .describe(
+      'Start of the queried time period, seconds since the Unix epoch.',
+    ),
+  to: z
+    .number()
+    .describe('End of the queried time period, seconds since the Unix epoch.'),
   query: z
     .string()
     .describe('Datadog metrics query string. e.g. "avg:system.cpu.user{*}'),
 })
 
-export type GetMetricsArgs = z.infer<typeof GetMetricsZodSchema>
+export type QueryMetricsArgs = z.infer<typeof QueryMetricsZodSchema>

--- a/src/tools/metrics/tool.ts
+++ b/src/tools/metrics/tool.ts
@@ -1,16 +1,16 @@
 import { ExtendedTool, ToolHandlers } from '../../utils/types'
 import { v1 } from '@datadog/datadog-api-client'
 import { createToolSchema } from '../../utils/tool'
-import { GetMetricsZodSchema } from './schema'
+import { QueryMetricsZodSchema } from './schema'
 
-type MetricsToolName = 'get_metrics'
+type MetricsToolName = 'query_metrics'
 type MetricsTool = ExtendedTool<MetricsToolName>
 
 export const METRICS_TOOLS: MetricsTool[] = [
   createToolSchema(
-    GetMetricsZodSchema,
-    'get_metrics',
-    'Get metrics data from Datadog',
+    QueryMetricsZodSchema,
+    'query_metrics',
+    'Query timeseries points of metrics from Datadog',
   ),
 ] as const
 
@@ -20,8 +20,8 @@ export const createMetricsToolHandlers = (
   apiInstance: v1.MetricsApi,
 ): MetricsToolHandlers => {
   return {
-    get_metrics: async (request) => {
-      const { from, to, query } = GetMetricsZodSchema.parse(
+    query_metrics: async (request) => {
+      const { from, to, query } = QueryMetricsZodSchema.parse(
         request.params.arguments,
       )
 
@@ -35,7 +35,7 @@ export const createMetricsToolHandlers = (
         content: [
           {
             type: 'text',
-            text: `Metrics data: ${JSON.stringify({ response })}`,
+            text: `Queried metrics data: ${JSON.stringify({ response })}`,
           },
         ],
       }

--- a/tests/tools/metrics.test.ts
+++ b/tests/tools/metrics.test.ts
@@ -86,11 +86,11 @@ describe('Metrics Tool', () => {
           to: 1641095000,
           query: 'avg:system.cpu.user{*}',
         })
-        const response = (await toolHandlers.get_metrics(
+        const response = (await toolHandlers.query_metrics(
           request,
         )) as unknown as DatadogToolResponse
 
-        expect(response.content[0].text).toContain('Metrics data:')
+        expect(response.content[0].text).toContain('Queried metrics data:')
         expect(response.content[0].text).toContain('system.cpu.user')
         expect(response.content[0].text).toContain('host:web-01')
         expect(response.content[0].text).toContain('host:web-02')
@@ -119,11 +119,11 @@ describe('Metrics Tool', () => {
           to: 1641095000,
           query: 'avg:non.existent.metric{*}',
         })
-        const response = (await toolHandlers.get_metrics(
+        const response = (await toolHandlers.query_metrics(
           request,
         )) as unknown as DatadogToolResponse
 
-        expect(response.content[0].text).toContain('Metrics data:')
+        expect(response.content[0].text).toContain('Queried metrics data:')
         expect(response.content[0].text).toContain('series":[]')
       })()
 
@@ -147,7 +147,7 @@ describe('Metrics Tool', () => {
           to: 1641095000,
           query: 'invalid:query:format',
         })
-        const response = (await toolHandlers.get_metrics(
+        const response = (await toolHandlers.query_metrics(
           request,
         )) as unknown as DatadogToolResponse
 
@@ -174,7 +174,7 @@ describe('Metrics Tool', () => {
           to: 1641095000,
           query: 'avg:system.cpu.user{*}',
         })
-        await expect(toolHandlers.get_metrics(request)).rejects.toThrow()
+        await expect(toolHandlers.query_metrics(request)).rejects.toThrow()
       })()
 
       server.close()
@@ -196,7 +196,7 @@ describe('Metrics Tool', () => {
           to: 1641095000,
           query: 'avg:system.cpu.user{*}',
         })
-        await expect(toolHandlers.get_metrics(request)).rejects.toThrow(
+        await expect(toolHandlers.query_metrics(request)).rejects.toThrow(
           'Rate limit exceeded',
         )
       })()
@@ -221,7 +221,7 @@ describe('Metrics Tool', () => {
           to: 1700000000, // Very recent date
           query: 'avg:system.cpu.user{*}',
         })
-        await expect(toolHandlers.get_metrics(request)).rejects.toThrow(
+        await expect(toolHandlers.query_metrics(request)).rejects.toThrow(
           'Time range exceeds allowed limit',
         )
       })()


### PR DESCRIPTION
Change `get_metrics` to `query_metrics`.

The `get_metrics` API is not calling "Get metric (metadata)", whose endpoint is `api/v1/metrics/{metric_name}`. Change the tool name to correspond to the official API Reference. Fix the parameter's description as well.

ref: https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points

---

**Note that** this change is a breaking change. Take care to merge.