### PR TITLE
fix: Add packages field to pnpm-workspace.yaml and update pnpm version requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -35,8 +36,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -53,8 +55,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -77,8 +80,9 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+
       - uses: pnpm/action-setup@v4
         with:
           version: 10
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -36,9 +38,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+
       - uses: pnpm/action-setup@v4
         with:
           version: 10
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -55,9 +59,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+
       - uses: pnpm/action-setup@v4
         with:
           version: 10
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "vitest": "^3.1.1"
   },
   "engines": {
-    "node": ">=16.17.0"
+    "node": ">=20.x",
+    "pnpm": ">=10"
   },
   "lint-staged": {
     "*.{js,ts}": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - .
+
 onlyBuiltDependencies:
   - esbuild
   - msw


### PR DESCRIPTION
## Why
This PR addresses an installation error that occurs with certain versions of pnpm due to a missing `packages` field in the `pnpm-workspace.yaml` file.

## Issue
When running `pnpm install`, users encounter the following error:
```bash
$ pnpm install
ERROR  packages field missing or empty
For help, run: pnpm help run
```
