### PR TITLE
Allow optional subdomain for Datadog enterprise accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,13 +212,15 @@ You need valid Datadog API credentials to use this MCP server:
 - `DATADOG_API_KEY`: Your Datadog API key
 - `DATADOG_APP_KEY`: Your Datadog Application key
 - `DATADOG_SITE` (optional): The Datadog site (e.g. `datadoghq.eu`)
+- `DATADOG_SUBDOMAIN` (optional): The Datadog subdomain (e.g. `<your-subdomain>.datadoghq.com`)
 
 Export them in your environment before running the server:
 
 ```bash
 export DATADOG_API_KEY="your_api_key"
 export DATADOG_APP_KEY="your_app_key"
-export DATADOG_SITE="your_datadog_site"
+export DATADOG_SITE="your_datadog_site" # Optional
+export DATADOG_SUBDOMAIN="your_datadog_subdomain" # Optional
 ```
 
 ## Installation
@@ -243,7 +245,7 @@ pnpm watch   # for development with auto-rebuild
 
 To use this with Claude Desktop, add the following to your `claude_desktop_config.json`:
 
-On MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`  
+On MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
 On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 
 ```json
@@ -268,7 +270,8 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
       "env": {
         "DATADOG_API_KEY": "<YOUR_API_KEY>",
         "DATADOG_APP_KEY": "<YOUR_APP_KEY>",
-        "DATADOG_SITE": "<YOUR_SITE>" // Optional
+        "DATADOG_SITE": "<YOUR_SITE>", // Optional
+        "DATADOG_SUBDOMAIN": "<YOUR_SUBDOMAIN>" // Optional
       }
     }
   }
@@ -286,7 +289,8 @@ Or specify via `npx`:
       "env": {
         "DATADOG_API_KEY": "<YOUR_API_KEY>",
         "DATADOG_APP_KEY": "<YOUR_APP_KEY>",
-        "DATADOG_SITE": "<YOUR_SITE>" // Optional
+        "DATADOG_SITE": "<YOUR_SITE>", // Optional
+        "DATADOG_SUBDOMAIN": "<YOUR_SUBDOMAIN>" // Optional
       }
     }
   }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -17,8 +17,12 @@ startCommand:
         description: Your Datadog Application key
       datadogSite:
         type: string
-        default: ''
+        default: ""
         description: Optional Datadog site (e.g. datadoghq.eu)
+      datadogSubdomain:
+        type: string
+        default: ""
+        description: Optional Datadog subdomain (e.g. <your-subdomain>.datadoghq.com)
   commandFunction:
     # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
     |-
@@ -28,10 +32,12 @@ startCommand:
       env: Object.assign({}, process.env, {
         DATADOG_API_KEY: config.datadogApiKey,
         DATADOG_APP_KEY: config.datadogAppKey,
-        ...(config.datadogSite && { DATADOG_SITE: config.datadogSite })
+        ...(config.datadogSite && { DATADOG_SITE: config.datadogSite }),
+        ...(config.datadogSubdomain && { DATADOG_SUBDOMAIN: config.datadogSubdomain })
       })
     })
   exampleConfig:
     datadogApiKey: your_datadog_api_key_here
     datadogAppKey: your_datadog_app_key_here
     datadogSite: datadoghq.com
+    datadogSubdomain: your-subdomain

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ const datadogConfig = createDatadogConfig({
   apiKeyAuth: process.env.DATADOG_API_KEY,
   appKeyAuth: process.env.DATADOG_APP_KEY,
   site: process.env.DATADOG_SITE,
+  subdomain: process.env.DATADOG_SUBDOMAIN,
 })
 
 const TOOL_HANDLERS: ToolHandlers = {

--- a/src/utils/datadog.ts
+++ b/src/utils/datadog.ts
@@ -4,6 +4,7 @@ interface CreateDatadogConfigParams {
   apiKeyAuth: string
   appKeyAuth: string
   site?: string
+  subdomain?: string
 }
 
 export function createDatadogConfig(
@@ -22,6 +23,12 @@ export function createDatadogConfig(
   if (config.site != null) {
     datadogConfig.setServerVariables({
       site: config.site,
+    })
+  }
+
+  if (config.subdomain != null) {
+    datadogConfig.setServerVariables({
+      subdomain: config.subdomain,
     })
   }
 

--- a/tests/utils/datadog.test.ts
+++ b/tests/utils/datadog.test.ts
@@ -35,6 +35,36 @@ describe('createDatadogConfig', () => {
     )
   })
 
+describe('createDatadogConfig', () => {
+  it('should create a datadog config with custom subdomain when DATADOG_SUBDOMAIN is configured', () => {
+    const datadogConfig = createDatadogConfig({
+      apiKeyAuth: 'test-api-key',
+      appKeyAuth: 'test-app-key',
+      subdomain: 'youryour-subdomain',
+    })
+    expect(datadogConfig.authMethods).toEqual({
+      apiKeyAuth: new ApiKeyAuthAuthentication('test-api-key'),
+      appKeyAuth: new AppKeyAuthAuthentication('test-app-key'),
+    })
+    expect(datadogConfig.servers[0]?.getConfiguration()?.subdomain).toBe(
+      'youryour-subdomain',
+    )
+  })
+
+  it('should create a datadog config with default subdomain when DATADOG_SUBDOMAIN is not configured', () => {
+    const datadogConfig = createDatadogConfig({
+      apiKeyAuth: 'test-api-key',
+      appKeyAuth: 'test-app-key',
+    })
+    expect(datadogConfig.authMethods).toEqual({
+      apiKeyAuth: new ApiKeyAuthAuthentication('test-api-key'),
+      appKeyAuth: new AppKeyAuthAuthentication('test-app-key'),
+    })
+    expect(datadogConfig.servers[0]?.getConfiguration()?.subdomain).toBe(
+      'api',
+    )
+  })
+
   it('should throw an error when DATADOG_API_KEY are not configured', () => {
     expect(() =>
       createDatadogConfig({


### PR DESCRIPTION
Hey!

My team uses custom Datadog [subdomains](https://docs.datadoghq.com/account_management/multi_organization/#custom-sub-domains) through our enterprise account.

We were getting an error when trying to use this MCP server, since it doesn't yet allow one to optionally specify a custom subdomain for the Datadog API endpoints.

This PR is to enable those with custom subdomains to still take advantage of this excellent tool, while maintaining backwards compatibility for those who do not use custom subdomains.

# BEFORE:

## EXAMPLE 1:

### ENV:

`datadogSite: datadoghq.com`

### REQUEST:
```
{
  "method": "tools/call",
  "params": {
    "name": "get_rum_applications",
    "arguments": {},
    "_meta": {
      "progressToken": 1
    }
  }
}
```

### RESPONSE:
```
{
  "error": "MCP error 403: HTTP-Code: 403\nMessage: \"Unknown API Status Code!\\nBody: \\\"{\\\"errors\\\":[\\\"Forbidden\\\"]}\\\"\""
}
```

## EXAMPLE 2:

### ENV:

`datadogSite: my-company.datadoghq.com`

### REQUEST:
```
{
  "method": "tools/call",
  "params": {
    "name": "get_rum_applications",
    "arguments": {},
    "_meta": {
      "progressToken": 1
    }
  }
}
```

### RESPONSE:
```
{
  "error": "MCP error -32603: request to https://api.my-company.datadoghq.com/api/v2/rum/applications failed, reason: Hostname/IP does not match certificate's altnames: Host: api.my-company.datadoghq.com. is not in the cert's altnames: DNS:*.datadoghq.com, DNS:datadoghq.com"
}
```


# AFTER:

## EXAMPLE

### ENV:

`datadogSite: datadoghq.com`
`datadogSubdomain: my-company`

### REQUEST:

```
{
  "method": "tools/call",
  "params": {
    "name": "get_rum_applications",
    "arguments": {},
    "_meta": {
      "progressToken": 0
    }
  }
}
```

### RESPONSE:
```
{
  "content": [
    {
      "type": "text",
      "text": "RUM applications: [...]"
    }
  ]
}
```

# Notes

- I also deployed and tested this PR on smithery.ai: https://smithery.ai/server/@AndrewJDawes/mcp-server-datadog