### PR TITLE
feat: add support for reading metric metadata and notebooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@datadog/datadog-api-client": "^1.34.1",
     "@modelcontextprotocol/sdk": "1.24.0",
-    "zod": "^3.24.3",
+    "zod": "^3.25.76",
     "zod-to-json-schema": "^3.24.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,13 +16,13 @@ importers:
         version: 1.34.1
       '@modelcontextprotocol/sdk':
         specifier: 1.24.0
-        version: 1.24.0(zod@3.24.3)
+        version: 1.24.0(zod@3.25.76)
       zod:
-        specifier: ^3.24.3
-        version: 3.24.3
+        specifier: ^3.25.76
+        version: 3.25.76
       zod-to-json-schema:
         specifier: ^3.24.5
-        version: 3.24.5(zod@3.24.3)
+        version: 3.24.5(zod@3.25.76)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.1
@@ -2822,8 +2822,8 @@ packages:
     peerDependencies:
       zod: ^3.25 || ^4
 
-  zod@3.24.3:
-    resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -3413,7 +3413,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@modelcontextprotocol/sdk@1.24.0(zod@3.24.3)':
+  '@modelcontextprotocol/sdk@1.24.0(zod@3.25.76)':
     dependencies:
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
@@ -3427,8 +3427,8 @@ snapshots:
       jose: 6.1.3
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.24.3
-      zod-to-json-schema: 3.25.0(zod@3.24.3)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.0(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -5818,12 +5818,12 @@ snapshots:
 
   yoctocolors-cjs@2.1.2: {}
 
-  zod-to-json-schema@3.24.5(zod@3.24.3):
+  zod-to-json-schema@3.24.5(zod@3.25.76):
     dependencies:
-      zod: 3.24.3
+      zod: 3.25.76
 
-  zod-to-json-schema@3.25.0(zod@3.24.3):
+  zod-to-json-schema@3.25.0(zod@3.25.76):
     dependencies:
-      zod: 3.24.3
+      zod: 3.25.76
 
-  zod@3.24.3: {}
+  zod@3.25.76: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { ToolHandlers } from './utils/types'
 import { createDatadogConfig } from './utils/datadog'
 import { createDowntimesToolHandlers, DOWNTIMES_TOOLS } from './tools/downtimes'
 import { createRumToolHandlers, RUM_TOOLS } from './tools/rum'
+import { createNotebooksToolHandlers, NOTEBOOKS_TOOLS } from './tools/notebooks'
 import { v2, v1 } from '@datadog/datadog-api-client'
 
 const server = new Server(
@@ -62,6 +63,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       ...HOSTS_TOOLS,
       ...DOWNTIMES_TOOLS,
       ...RUM_TOOLS,
+      ...NOTEBOOKS_TOOLS,
     ],
   }
 })
@@ -79,7 +81,10 @@ const datadogConfig = createDatadogConfig({
 
 const TOOL_HANDLERS: ToolHandlers = {
   ...createIncidentToolHandlers(new v2.IncidentsApi(datadogConfig)),
-  ...createMetricsToolHandlers(new v1.MetricsApi(datadogConfig)),
+  ...createMetricsToolHandlers(
+    new v1.MetricsApi(datadogConfig),
+    new v2.MetricsApi(datadogConfig),
+  ),
   ...createLogsToolHandlers(new v2.LogsApi(datadogConfig)),
   ...createMonitorsToolHandlers(new v1.MonitorsApi(datadogConfig)),
   ...createDashboardsToolHandlers(new v1.DashboardsApi(datadogConfig)),
@@ -87,6 +92,7 @@ const TOOL_HANDLERS: ToolHandlers = {
   ...createHostsToolHandlers(new v1.HostsApi(datadogConfig)),
   ...createDowntimesToolHandlers(new v1.DowntimesApi(datadogConfig)),
   ...createRumToolHandlers(new v2.RUMApi(datadogConfig)),
+  ...createNotebooksToolHandlers(new v1.NotebooksApi(datadogConfig)),
 }
 /**
  * Handler for invoking Datadog-related tools in the mcp-server-datadog.

--- a/src/tools/metrics/schema.ts
+++ b/src/tools/metrics/schema.ts
@@ -14,4 +14,48 @@ export const QueryMetricsZodSchema = z.object({
     .describe('Datadog metrics query string. e.g. "avg:system.cpu.user{*}'),
 })
 
+export const SearchMetricsZodSchema = z.object({
+  q: z
+    .string()
+    .describe(
+      'Query string to search metrics upon. Can optionally be prefixed with "metrics:". e.g. "system.cpu"',
+    ),
+})
+
+export const ListActiveMetricsZodSchema = z.object({
+  from: z
+    .number()
+    .describe(
+      'Seconds since the Unix epoch. List metrics that have been active since this time.',
+    ),
+  host: z
+    .string()
+    .optional()
+    .describe(
+      'Hostname for filtering the list of metrics returned. If set, metrics retrieved are those with the corresponding hostname tag.',
+    ),
+  tagFilter: z
+    .string()
+    .optional()
+    .describe(
+      'Filter metrics that have been submitted with the given tags. Supports boolean and wildcard expressions. Cannot be combined with other filters.',
+    ),
+})
+
+export const GetMetricMetadataZodSchema = z.object({
+  metricName: z
+    .string()
+    .describe('Name of the metric for which to get metadata.'),
+})
+
+export const ListTagsByMetricZodSchema = z.object({
+  metricName: z
+    .string()
+    .describe('The name of the metric to get tag key-value pairs for.'),
+})
+
 export type QueryMetricsArgs = z.infer<typeof QueryMetricsZodSchema>
+export type SearchMetricsArgs = z.infer<typeof SearchMetricsZodSchema>
+export type ListActiveMetricsArgs = z.infer<typeof ListActiveMetricsZodSchema>
+export type GetMetricMetadataArgs = z.infer<typeof GetMetricMetadataZodSchema>
+export type ListTagsByMetricArgs = z.infer<typeof ListTagsByMetricZodSchema>

--- a/src/tools/metrics/tool.ts
+++ b/src/tools/metrics/tool.ts
@@ -1,9 +1,20 @@
 import { ExtendedTool, ToolHandlers } from '../../utils/types'
-import { v1 } from '@datadog/datadog-api-client'
+import { v1, v2 } from '@datadog/datadog-api-client'
 import { createToolSchema } from '../../utils/tool'
-import { QueryMetricsZodSchema } from './schema'
+import {
+  QueryMetricsZodSchema,
+  SearchMetricsZodSchema,
+  ListActiveMetricsZodSchema,
+  GetMetricMetadataZodSchema,
+  ListTagsByMetricZodSchema,
+} from './schema'
 
-type MetricsToolName = 'query_metrics'
+type MetricsToolName =
+  | 'query_metrics'
+  | 'search_metrics'
+  | 'list_active_metrics'
+  | 'get_metric_metadata'
+  | 'list_tags_by_metric'
 type MetricsTool = ExtendedTool<MetricsToolName>
 
 export const METRICS_TOOLS: MetricsTool[] = [
@@ -12,12 +23,33 @@ export const METRICS_TOOLS: MetricsTool[] = [
     'query_metrics',
     'Query timeseries points of metrics from Datadog',
   ),
+  createToolSchema(
+    SearchMetricsZodSchema,
+    'search_metrics',
+    'Search for metrics from the last 24 hours in Datadog. Returns metric names matching the query.',
+  ),
+  createToolSchema(
+    ListActiveMetricsZodSchema,
+    'list_active_metrics',
+    'Get the list of actively reporting metrics from a given time until now.',
+  ),
+  createToolSchema(
+    GetMetricMetadataZodSchema,
+    'get_metric_metadata',
+    'Get metadata about a specific metric including description, unit, type, and more.',
+  ),
+  createToolSchema(
+    ListTagsByMetricZodSchema,
+    'list_tags_by_metric',
+    'View indexed tag key-value pairs for a given metric name over the previous hour.',
+  ),
 ] as const
 
 type MetricsToolHandlers = ToolHandlers<MetricsToolName>
 
 export const createMetricsToolHandlers = (
-  apiInstance: v1.MetricsApi,
+  v1ApiInstance: v1.MetricsApi,
+  v2ApiInstance: v2.MetricsApi,
 ): MetricsToolHandlers => {
   return {
     query_metrics: async (request) => {
@@ -25,7 +57,7 @@ export const createMetricsToolHandlers = (
         request.params.arguments,
       )
 
-      const response = await apiInstance.queryMetrics({
+      const response = await v1ApiInstance.queryMetrics({
         from,
         to,
         query,
@@ -36,6 +68,72 @@ export const createMetricsToolHandlers = (
           {
             type: 'text',
             text: `Queried metrics data: ${JSON.stringify({ response })}`,
+          },
+        ],
+      }
+    },
+    search_metrics: async (request) => {
+      const { q } = SearchMetricsZodSchema.parse(request.params.arguments)
+
+      const response = await v1ApiInstance.listMetrics({ q })
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Metrics search results: ${JSON.stringify(response)}`,
+          },
+        ],
+      }
+    },
+    list_active_metrics: async (request) => {
+      const { from, host, tagFilter } = ListActiveMetricsZodSchema.parse(
+        request.params.arguments,
+      )
+
+      const response = await v1ApiInstance.listActiveMetrics({
+        from,
+        host,
+        tagFilter,
+      })
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Active metrics: ${JSON.stringify(response)}`,
+          },
+        ],
+      }
+    },
+    get_metric_metadata: async (request) => {
+      const { metricName } = GetMetricMetadataZodSchema.parse(
+        request.params.arguments,
+      )
+
+      const response = await v1ApiInstance.getMetricMetadata({ metricName })
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Metric metadata for "${metricName}": ${JSON.stringify(response)}`,
+          },
+        ],
+      }
+    },
+    list_tags_by_metric: async (request) => {
+      const { metricName } = ListTagsByMetricZodSchema.parse(
+        request.params.arguments,
+      )
+
+      const response = await v2ApiInstance.listTagsByMetricName({ metricName })
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Tags for metric "${metricName}": ${JSON.stringify(response)}`,
           },
         ],
       }

--- a/src/tools/notebooks/index.ts
+++ b/src/tools/notebooks/index.ts
@@ -1,0 +1,1 @@
+export { NOTEBOOKS_TOOLS, createNotebooksToolHandlers } from './tool'

--- a/src/tools/notebooks/schema.ts
+++ b/src/tools/notebooks/schema.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod'
+
+export const ListNotebooksZodSchema = z.object({
+  authorHandle: z
+    .string()
+    .optional()
+    .describe('Return notebooks created by the given author_handle'),
+  excludeAuthorHandle: z
+    .string()
+    .optional()
+    .describe('Return notebooks not created by the given author_handle'),
+  start: z
+    .number()
+    .optional()
+    .describe('The index of the first notebook you want returned'),
+  count: z
+    .number()
+    .optional()
+    .describe('The number of notebooks to be returned'),
+  sortField: z
+    .enum(['modified', 'name', 'created'])
+    .optional()
+    .describe('Sort by field: modified, name, or created'),
+  sortDir: z
+    .enum(['asc', 'desc'])
+    .optional()
+    .describe('Sort by direction: asc or desc'),
+  query: z
+    .string()
+    .optional()
+    .describe(
+      'Return only notebooks with query string in notebook name or author handle',
+    ),
+  includeCells: z
+    .boolean()
+    .optional()
+    .describe(
+      'Value of false excludes the cells and global time for each notebook',
+    ),
+  isTemplate: z
+    .boolean()
+    .optional()
+    .describe(
+      'True value returns only template notebooks. Default is false (returns only non-template notebooks)',
+    ),
+  type: z
+    .string()
+    .optional()
+    .describe(
+      'If type is provided, returns only notebooks with that metadata type',
+    ),
+})
+
+export const GetNotebookZodSchema = z.object({
+  notebookId: z
+    .number()
+    .describe('Unique ID, assigned when you create the notebook'),
+})

--- a/src/tools/notebooks/tool.ts
+++ b/src/tools/notebooks/tool.ts
@@ -1,0 +1,92 @@
+import { ExtendedTool, ToolHandlers } from '../../utils/types'
+import { v1 } from '@datadog/datadog-api-client'
+import { createToolSchema } from '../../utils/tool'
+import { GetNotebookZodSchema, ListNotebooksZodSchema } from './schema'
+
+type NotebooksToolName = 'list_notebooks' | 'get_notebook'
+type NotebooksTool = ExtendedTool<NotebooksToolName>
+
+export const NOTEBOOKS_TOOLS: NotebooksTool[] = [
+  createToolSchema(
+    ListNotebooksZodSchema,
+    'list_notebooks',
+    'Get list of notebooks from Datadog',
+  ),
+  createToolSchema(
+    GetNotebookZodSchema,
+    'get_notebook',
+    'Get a notebook from Datadog',
+  ),
+] as const
+
+type NotebooksToolHandlers = ToolHandlers<NotebooksToolName>
+
+export const createNotebooksToolHandlers = (
+  apiInstance: v1.NotebooksApi,
+): NotebooksToolHandlers => {
+  return {
+    list_notebooks: async (request) => {
+      const {
+        authorHandle,
+        excludeAuthorHandle,
+        start,
+        count,
+        sortField,
+        sortDir,
+        query,
+        includeCells,
+        isTemplate,
+        type,
+      } = ListNotebooksZodSchema.parse(request.params.arguments)
+
+      const response = await apiInstance.listNotebooks({
+        authorHandle,
+        excludeAuthorHandle,
+        start,
+        count,
+        sortField,
+        sortDir,
+        query,
+        includeCells,
+        isTemplate,
+        type,
+      })
+
+      if (!response.data) {
+        throw new Error('No notebooks data returned')
+      }
+
+      const notebooks = response.data.map((notebook) => ({
+        ...notebook,
+        url: `https://app.datadoghq.com/notebook/${notebook.id}`,
+      }))
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Notebooks: ${JSON.stringify(notebooks)}`,
+          },
+        ],
+      }
+    },
+    get_notebook: async (request) => {
+      const { notebookId } = GetNotebookZodSchema.parse(
+        request.params.arguments,
+      )
+
+      const response = await apiInstance.getNotebook({
+        notebookId,
+      })
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Notebook: ${JSON.stringify(response)}`,
+          },
+        ],
+      }
+    },
+  }
+}

--- a/tests/tools/metrics.test.ts
+++ b/tests/tools/metrics.test.ts
@@ -1,4 +1,4 @@
-import { v1 } from '@datadog/datadog-api-client'
+import { v1, v2 } from '@datadog/datadog-api-client'
 import { describe, it, expect } from 'vitest'
 import { createDatadogConfig } from '../../src/utils/datadog'
 import { createMetricsToolHandlers } from '../../src/tools/metrics/tool'
@@ -8,6 +8,10 @@ import { setupServer } from '../helpers/msw'
 import { baseUrl, DatadogToolResponse } from '../helpers/datadog'
 
 const metricsEndpoint = `${baseUrl}/v1/query`
+const searchMetricsEndpoint = `${baseUrl}/v1/search`
+const activeMetricsEndpoint = `${baseUrl}/v1/metrics`
+const metricMetadataEndpoint = `${baseUrl}/v1/metrics`
+const tagsEndpoint = `${baseUrl}/v2/metrics`
 
 describe('Metrics Tool', () => {
   if (!process.env.DATADOG_API_KEY || !process.env.DATADOG_APP_KEY) {
@@ -20,8 +24,9 @@ describe('Metrics Tool', () => {
     site: process.env.DATADOG_SITE,
   })
 
-  const apiInstance = new v1.MetricsApi(datadogConfig)
-  const toolHandlers = createMetricsToolHandlers(apiInstance)
+  const v1ApiInstance = new v1.MetricsApi(datadogConfig)
+  const v2ApiInstance = new v2.MetricsApi(datadogConfig)
+  const toolHandlers = createMetricsToolHandlers(v1ApiInstance, v2ApiInstance)
 
   // https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-data-across-multiple-products
   describe.concurrent('query_metrics', async () => {
@@ -224,6 +229,374 @@ describe('Metrics Tool', () => {
         await expect(toolHandlers.query_metrics(request)).rejects.toThrow(
           'Time range exceeds allowed limit',
         )
+      })()
+
+      server.close()
+    })
+  })
+
+  // https://docs.datadoghq.com/api/latest/metrics/#search-metrics
+  describe.concurrent('search_metrics', async () => {
+    it('should search for metrics', async () => {
+      const mockHandler = http.get(searchMetricsEndpoint, async () => {
+        return HttpResponse.json({
+          results: {
+            metrics: [
+              'system.cpu.user',
+              'system.cpu.system',
+              'system.cpu.idle',
+              'system.cpu.iowait',
+            ],
+          },
+        })
+      })
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('search_metrics', {
+          q: 'system.cpu',
+        })
+        const response = (await toolHandlers.search_metrics(
+          request,
+        )) as unknown as DatadogToolResponse
+
+        expect(response.content[0].text).toContain('Metrics search results')
+        expect(response.content[0].text).toContain('system.cpu.user')
+        expect(response.content[0].text).toContain('system.cpu.system')
+      })()
+
+      server.close()
+    })
+
+    it('should handle empty search results', async () => {
+      const mockHandler = http.get(searchMetricsEndpoint, async () => {
+        return HttpResponse.json({
+          results: {
+            metrics: [],
+          },
+        })
+      })
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('search_metrics', {
+          q: 'nonexistent.metric.name',
+        })
+        const response = (await toolHandlers.search_metrics(
+          request,
+        )) as unknown as DatadogToolResponse
+
+        expect(response.content[0].text).toContain('Metrics search results')
+        expect(response.content[0].text).toContain('metrics":[]')
+      })()
+
+      server.close()
+    })
+
+    it('should handle authentication errors', async () => {
+      const mockHandler = http.get(searchMetricsEndpoint, async () => {
+        return HttpResponse.json(
+          { errors: ['Authentication failed'] },
+          { status: 403 },
+        )
+      })
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('search_metrics', {
+          q: 'system.cpu',
+        })
+        await expect(toolHandlers.search_metrics(request)).rejects.toThrow()
+      })()
+
+      server.close()
+    })
+  })
+
+  // https://docs.datadoghq.com/api/latest/metrics/#get-active-metrics-list
+  describe.concurrent('list_active_metrics', async () => {
+    it('should list active metrics', async () => {
+      const mockHandler = http.get(activeMetricsEndpoint, async () => {
+        return HttpResponse.json({
+          metrics: ['system.cpu.user', 'system.mem.used', 'system.disk.total'],
+          from: '1640995000',
+        })
+      })
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('list_active_metrics', {
+          from: 1640995000,
+        })
+        const response = (await toolHandlers.list_active_metrics(
+          request,
+        )) as unknown as DatadogToolResponse
+
+        expect(response.content[0].text).toContain('Active metrics')
+        expect(response.content[0].text).toContain('system.cpu.user')
+        expect(response.content[0].text).toContain('system.mem.used')
+      })()
+
+      server.close()
+    })
+
+    it('should list active metrics with host filter', async () => {
+      const mockHandler = http.get(activeMetricsEndpoint, async () => {
+        return HttpResponse.json({
+          metrics: ['system.cpu.user'],
+          from: '1640995000',
+        })
+      })
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('list_active_metrics', {
+          from: 1640995000,
+          host: 'web-01',
+        })
+        const response = (await toolHandlers.list_active_metrics(
+          request,
+        )) as unknown as DatadogToolResponse
+
+        expect(response.content[0].text).toContain('Active metrics')
+        expect(response.content[0].text).toContain('system.cpu.user')
+      })()
+
+      server.close()
+    })
+
+    it('should list active metrics with tag filter', async () => {
+      const mockHandler = http.get(activeMetricsEndpoint, async () => {
+        return HttpResponse.json({
+          metrics: ['custom.metric.production'],
+          from: '1640995000',
+        })
+      })
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('list_active_metrics', {
+          from: 1640995000,
+          tagFilter: 'env:production',
+        })
+        const response = (await toolHandlers.list_active_metrics(
+          request,
+        )) as unknown as DatadogToolResponse
+
+        expect(response.content[0].text).toContain('Active metrics')
+        expect(response.content[0].text).toContain('custom.metric.production')
+      })()
+
+      server.close()
+    })
+
+    it('should handle authentication errors', async () => {
+      const mockHandler = http.get(activeMetricsEndpoint, async () => {
+        return HttpResponse.json(
+          { errors: ['Authentication failed'] },
+          { status: 403 },
+        )
+      })
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('list_active_metrics', {
+          from: 1640995000,
+        })
+        await expect(
+          toolHandlers.list_active_metrics(request),
+        ).rejects.toThrow()
+      })()
+
+      server.close()
+    })
+  })
+
+  // https://docs.datadoghq.com/api/latest/metrics/#get-metric-metadata
+  describe.concurrent('get_metric_metadata', async () => {
+    it('should get metric metadata', async () => {
+      const metricName = 'system.cpu.user'
+      const mockHandler = http.get(
+        `${metricMetadataEndpoint}/${metricName}`,
+        async () => {
+          return HttpResponse.json({
+            description: 'Percentage of CPU time spent in user space',
+            short_name: 'cpu user',
+            integration: 'system',
+            statsd_interval: 10,
+            per_unit: null,
+            unit: 'percent',
+            type: 'gauge',
+          })
+        },
+      )
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('get_metric_metadata', {
+          metricName,
+        })
+        const response = (await toolHandlers.get_metric_metadata(
+          request,
+        )) as unknown as DatadogToolResponse
+
+        expect(response.content[0].text).toContain('Metric metadata')
+        expect(response.content[0].text).toContain('system.cpu.user')
+        expect(response.content[0].text).toContain('Percentage of CPU time')
+        expect(response.content[0].text).toContain('percent')
+        expect(response.content[0].text).toContain('gauge')
+      })()
+
+      server.close()
+    })
+
+    it('should handle not found errors', async () => {
+      const metricName = 'nonexistent.metric'
+      const mockHandler = http.get(
+        `${metricMetadataEndpoint}/${metricName}`,
+        async () => {
+          return HttpResponse.json(
+            { errors: ['Metric not found'] },
+            { status: 404 },
+          )
+        },
+      )
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('get_metric_metadata', {
+          metricName,
+        })
+        await expect(toolHandlers.get_metric_metadata(request)).rejects.toThrow(
+          'Metric not found',
+        )
+      })()
+
+      server.close()
+    })
+
+    it('should handle authentication errors', async () => {
+      const metricName = 'system.cpu.user'
+      const mockHandler = http.get(
+        `${metricMetadataEndpoint}/${metricName}`,
+        async () => {
+          return HttpResponse.json(
+            { errors: ['Authentication failed'] },
+            { status: 403 },
+          )
+        },
+      )
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('get_metric_metadata', {
+          metricName,
+        })
+        await expect(
+          toolHandlers.get_metric_metadata(request),
+        ).rejects.toThrow()
+      })()
+
+      server.close()
+    })
+  })
+
+  // https://docs.datadoghq.com/api/latest/metrics/#list-tags-by-metric-name
+  describe.concurrent('list_tags_by_metric', async () => {
+    it('should list tags for a metric', async () => {
+      const metricName = 'system.cpu.user'
+      const mockHandler = http.get(
+        `${tagsEndpoint}/${metricName}/all-tags`,
+        async () => {
+          return HttpResponse.json({
+            data: {
+              id: 'system.cpu.user',
+              type: 'metrics',
+              attributes: {
+                tags: ['host', 'env', 'service', 'region'],
+              },
+            },
+          })
+        },
+      )
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('list_tags_by_metric', {
+          metricName,
+        })
+        const response = (await toolHandlers.list_tags_by_metric(
+          request,
+        )) as unknown as DatadogToolResponse
+
+        expect(response.content[0].text).toContain('Tags for metric')
+        expect(response.content[0].text).toContain('system.cpu.user')
+        expect(response.content[0].text).toContain('host')
+        expect(response.content[0].text).toContain('env')
+        expect(response.content[0].text).toContain('service')
+      })()
+
+      server.close()
+    })
+
+    it('should handle not found errors', async () => {
+      const metricName = 'nonexistent.metric'
+      const mockHandler = http.get(
+        `${tagsEndpoint}/${metricName}/all-tags`,
+        async () => {
+          return HttpResponse.json(
+            { errors: ['Metric not found'] },
+            { status: 404 },
+          )
+        },
+      )
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('list_tags_by_metric', {
+          metricName,
+        })
+        await expect(toolHandlers.list_tags_by_metric(request)).rejects.toThrow(
+          'Metric not found',
+        )
+      })()
+
+      server.close()
+    })
+
+    it('should handle authentication errors', async () => {
+      const metricName = 'system.cpu.user'
+      const mockHandler = http.get(
+        `${tagsEndpoint}/${metricName}/all-tags`,
+        async () => {
+          return HttpResponse.json(
+            { errors: ['Authentication failed'] },
+            { status: 403 },
+          )
+        },
+      )
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('list_tags_by_metric', {
+          metricName,
+        })
+        await expect(
+          toolHandlers.list_tags_by_metric(request),
+        ).rejects.toThrow()
       })()
 
       server.close()

--- a/tests/tools/notebooks.test.ts
+++ b/tests/tools/notebooks.test.ts
@@ -1,0 +1,274 @@
+import { v1 } from '@datadog/datadog-api-client'
+import { describe, it, expect } from 'vitest'
+import { createDatadogConfig } from '../../src/utils/datadog'
+import { createNotebooksToolHandlers } from '../../src/tools/notebooks/tool'
+import { createMockToolRequest } from '../helpers/mock'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from '../helpers/msw'
+import { baseUrl, DatadogToolResponse } from '../helpers/datadog'
+
+const notebookEndpoint = `${baseUrl}/v1/notebooks`
+
+describe('Notebooks Tool', () => {
+  if (!process.env.DATADOG_API_KEY || !process.env.DATADOG_APP_KEY) {
+    throw new Error('DATADOG_API_KEY and DATADOG_APP_KEY must be set')
+  }
+
+  const datadogConfig = createDatadogConfig({
+    apiKeyAuth: process.env.DATADOG_API_KEY,
+    appKeyAuth: process.env.DATADOG_APP_KEY,
+    site: process.env.DATADOG_SITE,
+  })
+
+  const apiInstance = new v1.NotebooksApi(datadogConfig)
+  const toolHandlers = createNotebooksToolHandlers(apiInstance)
+
+  // https://docs.datadoghq.com/api/latest/notebooks/#get-all-notebooks
+  describe.concurrent('list_notebooks', async () => {
+    it('should list notebooks', async () => {
+      const mockHandler = http.get(notebookEndpoint, async () => {
+        return HttpResponse.json({
+          data: [
+            {
+              id: 123456,
+              type: 'notebooks',
+              attributes: {
+                name: 'Test Notebook',
+                author: {
+                  handle: 'test@example.com',
+                },
+                created: '2023-01-01T00:00:00Z',
+                modified: '2023-01-02T00:00:00Z',
+              },
+            },
+          ],
+        })
+      })
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('list_notebooks', {
+          query: 'test',
+        })
+        const response = (await toolHandlers.list_notebooks(
+          request,
+        )) as unknown as DatadogToolResponse
+        expect(response.content[0].text).toContain('Notebooks')
+        expect(response.content[0].text).toContain('123456')
+        expect(response.content[0].text).toContain(
+          'https://app.datadoghq.com/notebook/123456',
+        )
+      })()
+
+      server.close()
+    })
+
+    it('should list notebooks with all filter options', async () => {
+      const mockHandler = http.get(notebookEndpoint, async () => {
+        return HttpResponse.json({
+          data: [
+            {
+              id: 789,
+              type: 'notebooks',
+              attributes: {
+                name: 'Filtered Notebook',
+              },
+            },
+          ],
+        })
+      })
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('list_notebooks', {
+          authorHandle: 'author@example.com',
+          excludeAuthorHandle: 'exclude@example.com',
+          start: 0,
+          count: 10,
+          sortField: 'modified',
+          sortDir: 'desc',
+          query: 'filtered',
+          includeCells: false,
+          isTemplate: false,
+          type: 'investigation',
+        })
+        const response = (await toolHandlers.list_notebooks(
+          request,
+        )) as unknown as DatadogToolResponse
+        expect(response.content[0].text).toContain('Notebooks')
+        expect(response.content[0].text).toContain('789')
+      })()
+
+      server.close()
+    })
+
+    it('should handle authentication errors', async () => {
+      const mockHandler = http.get(notebookEndpoint, async () => {
+        return HttpResponse.json(
+          { errors: ['dummy authentication error'] },
+          { status: 403 },
+        )
+      })
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('list_notebooks', {})
+        await expect(toolHandlers.list_notebooks(request)).rejects.toThrow(
+          'dummy authentication error',
+        )
+      })()
+
+      server.close()
+    })
+
+    it('should handle too many requests', async () => {
+      const mockHandler = http.get(notebookEndpoint, async () => {
+        return HttpResponse.json(
+          { errors: ['dummy too many requests'] },
+          { status: 429 },
+        )
+      })
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('list_notebooks', {})
+        await expect(toolHandlers.list_notebooks(request)).rejects.toThrow(
+          'dummy too many requests',
+        )
+      })()
+
+      server.close()
+    })
+
+    it('should handle unknown errors', async () => {
+      const mockHandler = http.get(notebookEndpoint, async () => {
+        return HttpResponse.json(
+          { errors: ['dummy unknown error'] },
+          { status: 500 },
+        )
+      })
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('list_notebooks', {})
+        await expect(toolHandlers.list_notebooks(request)).rejects.toThrow(
+          'dummy unknown error',
+        )
+      })()
+
+      server.close()
+    })
+  })
+
+  // https://docs.datadoghq.com/api/latest/notebooks/#get-a-notebook
+  describe.concurrent('get_notebook', async () => {
+    it('should get a notebook', async () => {
+      const notebookId = 123456789
+      const mockHandler = http.get(
+        `${notebookEndpoint}/${notebookId}`,
+        async () => {
+          return HttpResponse.json({
+            data: {
+              id: 123456789,
+              type: 'notebooks',
+              attributes: {
+                name: 'Test Notebook',
+                author: {
+                  handle: 'test@example.com',
+                },
+                cells: [
+                  {
+                    id: 'cell1',
+                    type: 'notebook_cells',
+                    attributes: {
+                      definition: {
+                        type: 'markdown',
+                        text: '# Hello World',
+                      },
+                    },
+                  },
+                ],
+                created: '2023-01-01T00:00:00Z',
+                modified: '2023-01-02T00:00:00Z',
+                time: {
+                  live_span: '1h',
+                },
+              },
+            },
+          })
+        },
+      )
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('get_notebook', {
+          notebookId,
+        })
+        const response = (await toolHandlers.get_notebook(
+          request,
+        )) as unknown as DatadogToolResponse
+
+        expect(response.content[0].text).toContain('Notebook')
+        expect(response.content[0].text).toContain('123456789')
+        expect(response.content[0].text).toContain('Test Notebook')
+      })()
+
+      server.close()
+    })
+
+    it('should handle not found errors', async () => {
+      const notebookId = 999999999
+      const mockHandler = http.get(
+        `${notebookEndpoint}/${notebookId}`,
+        async () => {
+          return HttpResponse.json({ errors: ['Not found'] }, { status: 404 })
+        },
+      )
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('get_notebook', {
+          notebookId,
+        })
+        await expect(toolHandlers.get_notebook(request)).rejects.toThrow(
+          'Not found',
+        )
+      })()
+
+      server.close()
+    })
+
+    it('should handle server errors', async () => {
+      const notebookId = 123456789
+      const mockHandler = http.get(
+        `${notebookEndpoint}/${notebookId}`,
+        async () => {
+          return HttpResponse.json(
+            { errors: ['Internal server error'] },
+            { status: 500 },
+          )
+        },
+      )
+
+      const server = setupServer(mockHandler)
+
+      await server.boundary(async () => {
+        const request = createMockToolRequest('get_notebook', {
+          notebookId,
+        })
+        await expect(toolHandlers.get_notebook(request)).rejects.toThrow(
+          'Internal server error',
+        )
+      })()
+
+      server.close()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Add support for querying Datadog Notebooks API and enhance metrics discovery capabilities with new search tools.

## Changes

### Notebooks API Support

- Add `list_notebooks` tool to list/search notebooks with filtering options (author, query, type, pagination, sorting)
- Add `get_notebook` tool to retrieve a specific notebook by ID

### Metrics Search Tools

- Add `search_metrics` tool to search for metric names from the last 24 hours
- Add `list_active_metrics` tool to list actively reporting metrics since a given time with optional host/tag filters
- Add `get_metric_metadata` tool to get detailed metadata (description, unit, type) for a specific metric
- Add `list_tags_by_metric` tool to view indexed tag key-value pairs for a metric

### Dependency Fix

- Update `zod` from `^3.24.3` to `^3.25.76` to fix compatibility with `@modelcontextprotocol/sdk@1.24.0`

## New Tools

| Tool | Description |
|------|-------------|
| `list_notebooks` | List/search notebooks with filtering options |
| `get_notebook` | Get a specific notebook by ID |
| `search_metrics` | Search for metrics by name pattern |
| `list_active_metrics` | List actively reporting metrics |
| `get_metric_metadata` | Get metadata for a specific metric |
| `list_tags_by_metric` | Get tag key-value pairs for a metric |

## Testing
- Added 8 tests for notebooks tools
- Added 13 tests for new metrics tools