### PR TITLE
feat: add audit log tools and cursor-based pagination across all list tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { ToolHandlers } from './utils/types'
 import { createDatadogConfig } from './utils/datadog'
 import { createDowntimesToolHandlers, DOWNTIMES_TOOLS } from './tools/downtimes'
 import { createRumToolHandlers, RUM_TOOLS } from './tools/rum'
+import { AUDIT_TOOLS, createAuditToolHandlers } from './tools/audit'
 import { v2, v1 } from '@datadog/datadog-api-client'
 
 const server = new Server(
@@ -62,6 +63,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       ...HOSTS_TOOLS,
       ...DOWNTIMES_TOOLS,
       ...RUM_TOOLS,
+      ...AUDIT_TOOLS,
     ],
   }
 })
@@ -87,6 +89,7 @@ const TOOL_HANDLERS: ToolHandlers = {
   ...createHostsToolHandlers(new v1.HostsApi(datadogConfig)),
   ...createDowntimesToolHandlers(new v1.DowntimesApi(datadogConfig)),
   ...createRumToolHandlers(new v2.RUMApi(datadogConfig)),
+  ...createAuditToolHandlers(new v2.AuditApi(datadogConfig)),
 }
 /**
  * Handler for invoking Datadog-related tools in the mcp-server-datadog.

--- a/src/tools/audit/index.ts
+++ b/src/tools/audit/index.ts
@@ -1,0 +1,1 @@
+export { AUDIT_TOOLS, createAuditToolHandlers } from './tool'

--- a/src/tools/audit/schema.ts
+++ b/src/tools/audit/schema.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+
+export const ListAuditLogsZodSchema = z.object({
+  query: z
+    .string()
+    .default('')
+    .describe(
+      'Datadog audit logs query string (e.g. @asset.type:monitor @asset.id:12345)',
+    ),
+  from: z.number().describe('Start time in epoch seconds'),
+  to: z.number().describe('End time in epoch seconds'),
+  limit: z
+    .number()
+    .optional()
+    .default(25)
+    .describe('Maximum number of audit events to return. Default is 25.'),
+})
+
+export const SearchAuditLogsZodSchema = z.object({
+  query: z
+    .string()
+    .default('')
+    .describe(
+      'Datadog audit logs query string (e.g. @asset.type:monitor @asset.id:12345)',
+    ),
+  from: z.number().describe('Start time in epoch seconds'),
+  to: z.number().describe('End time in epoch seconds'),
+  limit: z
+    .number()
+    .optional()
+    .default(25)
+    .describe('Maximum number of audit events to return. Default is 25.'),
+  sort: z
+    .string()
+    .optional()
+    .default('-timestamp')
+    .describe(
+      'Sort order for results. Use -timestamp for newest first, timestamp for oldest first.',
+    ),
+})

--- a/src/tools/audit/schema.ts
+++ b/src/tools/audit/schema.ts
@@ -13,7 +13,9 @@ export const ListAuditLogsZodSchema = z.object({
     .number()
     .optional()
     .default(25)
-    .describe('Maximum number of audit events to return. Default is 25.'),
+    .describe(
+      'Maximum number of audit events to return. Set 0 for unlimited (auto-paginates all results).',
+    ),
 })
 
 export const SearchAuditLogsZodSchema = z.object({
@@ -29,7 +31,9 @@ export const SearchAuditLogsZodSchema = z.object({
     .number()
     .optional()
     .default(25)
-    .describe('Maximum number of audit events to return. Default is 25.'),
+    .describe(
+      'Maximum number of audit events to return. Set 0 for unlimited (auto-paginates all results).',
+    ),
   sort: z
     .string()
     .optional()

--- a/src/tools/audit/tool.ts
+++ b/src/tools/audit/tool.ts
@@ -1,0 +1,85 @@
+import { v2 } from '@datadog/datadog-api-client'
+import { createToolSchema } from '../../utils/tool'
+import { ExtendedTool, ToolHandlers } from '../../utils/types'
+import { ListAuditLogsZodSchema, SearchAuditLogsZodSchema } from './schema'
+
+type AuditToolName = 'list_audit_logs' | 'search_audit_logs'
+type AuditTool = ExtendedTool<AuditToolName>
+
+export const AUDIT_TOOLS: AuditTool[] = [
+  createToolSchema(
+    ListAuditLogsZodSchema,
+    'list_audit_logs',
+    'List audit log events from Datadog with simple filtering',
+  ),
+  createToolSchema(
+    SearchAuditLogsZodSchema,
+    'search_audit_logs',
+    'Search audit log events from Datadog with structured query and sorting',
+  ),
+] as const
+
+type AuditToolHandlers = ToolHandlers<AuditToolName>
+
+export const createAuditToolHandlers = (
+  apiInstance: v2.AuditApi,
+): AuditToolHandlers => ({
+  list_audit_logs: async (request) => {
+    const { query, from, to, limit } = ListAuditLogsZodSchema.parse(
+      request.params.arguments,
+    )
+
+    const response = await apiInstance.listAuditLogs({
+      filterQuery: query,
+      filterFrom: new Date(from * 1000),
+      filterTo: new Date(to * 1000),
+      pageLimit: limit,
+    })
+
+    if (response.data == null) {
+      throw new Error('No audit log data returned')
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Audit logs: ${JSON.stringify(response.data)}`,
+        },
+      ],
+    }
+  },
+
+  search_audit_logs: async (request) => {
+    const { query, from, to, limit, sort } = SearchAuditLogsZodSchema.parse(
+      request.params.arguments,
+    )
+
+    const response = await apiInstance.searchAuditLogs({
+      body: {
+        filter: {
+          query,
+          from: new Date(from * 1000).toISOString(),
+          to: new Date(to * 1000).toISOString(),
+        },
+        page: {
+          limit,
+        },
+        sort: sort as v2.AuditLogsSort,
+      },
+    })
+
+    if (response.data == null) {
+      throw new Error('No audit log data returned')
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Audit logs: ${JSON.stringify(response.data)}`,
+        },
+      ],
+    }
+  },
+})

--- a/src/tools/audit/tool.ts
+++ b/src/tools/audit/tool.ts
@@ -29,22 +29,45 @@ export const createAuditToolHandlers = (
       request.params.arguments,
     )
 
-    const response = await apiInstance.listAuditLogs({
-      filterQuery: query,
-      filterFrom: new Date(from * 1000),
-      filterTo: new Date(to * 1000),
-      pageLimit: limit,
-    })
+    const unlimited = limit === 0
+    const allEvents: v2.AuditLogsEvent[] = []
+    let cursor: string | undefined
 
-    if (response.data == null) {
+    while (unlimited || allEvents.length < limit) {
+      const pageLimit = unlimited
+        ? 1000
+        : Math.min(limit - allEvents.length, 1000)
+      const response = await apiInstance.listAuditLogs({
+        filterQuery: query,
+        filterFrom: new Date(from * 1000),
+        filterTo: new Date(to * 1000),
+        pageLimit,
+        ...(cursor ? { pageCursor: cursor } : {}),
+      })
+
+      if (!response.data || response.data.length === 0) {
+        break
+      }
+
+      allEvents.push(...response.data)
+
+      cursor = response.meta?.page?.after
+      if (!cursor) {
+        break
+      }
+    }
+
+    if (allEvents.length === 0) {
       throw new Error('No audit log data returned')
     }
+
+    const result = unlimited ? allEvents : allEvents.slice(0, limit)
 
     return {
       content: [
         {
           type: 'text',
-          text: `Audit logs: ${JSON.stringify(response.data)}`,
+          text: `Audit logs: ${JSON.stringify(result)}`,
         },
       ],
     }
@@ -55,29 +78,49 @@ export const createAuditToolHandlers = (
       request.params.arguments,
     )
 
-    const response = await apiInstance.searchAuditLogs({
-      body: {
-        filter: {
-          query,
-          from: new Date(from * 1000).toISOString(),
-          to: new Date(to * 1000).toISOString(),
-        },
-        page: {
-          limit,
-        },
-        sort: sort as v2.AuditLogsSort,
-      },
-    })
+    const unlimited = limit === 0
+    const allEvents: v2.AuditLogsEvent[] = []
+    let cursor: string | undefined
 
-    if (response.data == null) {
+    while (unlimited || allEvents.length < limit) {
+      const pageLimit = unlimited
+        ? 1000
+        : Math.min(limit - allEvents.length, 1000)
+      const response = await apiInstance.searchAuditLogs({
+        body: {
+          filter: {
+            query,
+            from: new Date(from * 1000).toISOString(),
+            to: new Date(to * 1000).toISOString(),
+          },
+          page: { limit: pageLimit, ...(cursor ? { cursor } : {}) },
+          sort: sort as v2.AuditLogsSort,
+        },
+      })
+
+      if (!response.data || response.data.length === 0) {
+        break
+      }
+
+      allEvents.push(...response.data)
+
+      cursor = response.meta?.page?.after
+      if (!cursor) {
+        break
+      }
+    }
+
+    if (allEvents.length === 0) {
       throw new Error('No audit log data returned')
     }
+
+    const result = unlimited ? allEvents : allEvents.slice(0, limit)
 
     return {
       content: [
         {
           type: 'text',
-          text: `Audit logs: ${JSON.stringify(response.data)}`,
+          text: `Audit logs: ${JSON.stringify(result)}`,
         },
       ],
     }

--- a/src/tools/logs/schema.ts
+++ b/src/tools/logs/schema.ts
@@ -8,7 +8,9 @@ export const GetLogsZodSchema = z.object({
     .number()
     .optional()
     .default(100)
-    .describe('Maximum number of logs to return. Default is 100.'),
+    .describe(
+      'Maximum number of logs to return. Set 0 for unlimited (auto-paginates all results).',
+    ),
 })
 
 /**
@@ -31,5 +33,7 @@ export const GetAllServicesZodSchema = z.object({
     .number()
     .optional()
     .default(1000)
-    .describe('Maximum number of logs to search through. Default is 1000.'),
+    .describe(
+      'Maximum number of logs to search through. Set 0 for unlimited (auto-paginates all results).',
+    ),
 })

--- a/src/tools/logs/tool.ts
+++ b/src/tools/logs/tool.ts
@@ -72,25 +72,45 @@ export const createLogsToolHandlers = (
       filter.storageTier = configuredStorageTier
     }
 
-    const response = await apiInstance.listLogs({
-      body: {
-        filter,
-        page: {
-          limit,
-        },
-        sort: '-timestamp',
-      },
-    })
+    const unlimited = limit === 0
+    const allLogs: v2.Log[] = []
+    let cursor: string | undefined
 
-    if (response.data == null) {
+    while (unlimited || allLogs.length < limit) {
+      const pageLimit = unlimited
+        ? 1000
+        : Math.min(limit - allLogs.length, 1000)
+      const response = await apiInstance.listLogs({
+        body: {
+          filter,
+          page: { limit: pageLimit, ...(cursor ? { cursor } : {}) },
+          sort: '-timestamp',
+        },
+      })
+
+      if (!response.data || response.data.length === 0) {
+        break
+      }
+
+      allLogs.push(...response.data)
+
+      cursor = response.meta?.page?.after
+      if (!cursor) {
+        break
+      }
+    }
+
+    if (allLogs.length === 0) {
       throw new Error('No logs data returned')
     }
+
+    const result = unlimited ? allLogs : allLogs.slice(0, limit)
 
     return {
       content: [
         {
           type: 'text',
-          text: `Logs data: ${JSON.stringify(response.data)}`,
+          text: `Logs data: ${JSON.stringify(result)}`,
         },
       ],
     }
@@ -119,28 +139,43 @@ export const createLogsToolHandlers = (
       filter.storageTier = configuredStorageTier
     }
 
-    const response = await apiInstance.listLogs({
-      body: {
-        filter,
-        page: {
-          limit,
-        },
-        sort: '-timestamp',
-      },
-    })
+    const unlimited = limit === 0
+    const services = new Set<string>()
+    let cursor: string | undefined
+    let totalLogsProcessed = 0
 
-    if (response.data == null) {
-      throw new Error('No logs data returned')
+    while (unlimited || totalLogsProcessed < limit) {
+      const pageLimit = unlimited
+        ? 1000
+        : Math.min(limit - totalLogsProcessed, 1000)
+      const response = await apiInstance.listLogs({
+        body: {
+          filter,
+          page: { limit: pageLimit, ...(cursor ? { cursor } : {}) },
+          sort: '-timestamp',
+        },
+      })
+
+      if (!response.data || response.data.length === 0) {
+        break
+      }
+
+      for (const logEntry of response.data) {
+        if (logEntry.attributes && logEntry.attributes.service) {
+          services.add(logEntry.attributes.service)
+        }
+      }
+
+      totalLogsProcessed += response.data.length
+
+      cursor = response.meta?.page?.after
+      if (!cursor) {
+        break
+      }
     }
 
-    // Extract unique services from logs
-    const services = new Set<string>()
-
-    for (const log of response.data) {
-      // Access service attribute from logs based on the Datadog API structure
-      if (log.attributes && log.attributes.service) {
-        services.add(log.attributes.service)
-      }
+    if (services.size === 0) {
+      throw new Error('No logs data returned')
     }
 
     return {

--- a/src/tools/rum/schema.ts
+++ b/src/tools/rum/schema.ts
@@ -17,7 +17,9 @@ export const GetRumEventsZodSchema = z.object({
     .number()
     .optional()
     .default(100)
-    .describe('Maximum number of events to return. Default is 100.'),
+    .describe(
+      'Maximum number of events to return. Set 0 for unlimited (auto-paginates all results).',
+    ),
 })
 
 /**

--- a/src/tools/rum/tool.ts
+++ b/src/tools/rum/tool.ts
@@ -74,23 +74,46 @@ export const createRumToolHandlers = (
       request.params.arguments,
     )
 
-    const response = await apiInstance.listRUMEvents({
-      filterQuery: query,
-      filterFrom: new Date(from * 1000),
-      filterTo: new Date(to * 1000),
-      sort: 'timestamp',
-      pageLimit: limit,
-    })
+    const unlimited = limit === 0
+    const allEvents: v2.RUMEvent[] = []
+    let cursor: string | undefined
 
-    if (response.data == null) {
+    while (unlimited || allEvents.length < limit) {
+      const pageLimit = unlimited
+        ? 1000
+        : Math.min(limit - allEvents.length, 1000)
+      const response = await apiInstance.listRUMEvents({
+        filterQuery: query,
+        filterFrom: new Date(from * 1000),
+        filterTo: new Date(to * 1000),
+        sort: 'timestamp',
+        pageLimit,
+        ...(cursor ? { pageCursor: cursor } : {}),
+      })
+
+      if (!response.data || response.data.length === 0) {
+        break
+      }
+
+      allEvents.push(...response.data)
+
+      cursor = response.meta?.page?.after
+      if (!cursor) {
+        break
+      }
+    }
+
+    if (allEvents.length === 0) {
       throw new Error('No RUM events data returned')
     }
+
+    const result = unlimited ? allEvents : allEvents.slice(0, limit)
 
     return {
       content: [
         {
           type: 'text',
-          text: `RUM events data: ${JSON.stringify(response.data)}`,
+          text: `RUM events data: ${JSON.stringify(result)}`,
         },
       ],
     }
@@ -101,23 +124,40 @@ export const createRumToolHandlers = (
       request.params.arguments,
     )
 
-    // For session counts, we need to use a query to count unique sessions
-    const response = await apiInstance.listRUMEvents({
-      filterQuery: query !== '*' ? query : undefined,
-      filterFrom: new Date(from * 1000),
-      filterTo: new Date(to * 1000),
-      sort: 'timestamp',
-      pageLimit: 2000,
-    })
+    // Paginate to collect all matching events
+    const allEvents: v2.RUMEvent[] = []
+    let cursor: string | undefined
 
-    if (response.data == null) {
+    while (true) {
+      const response = await apiInstance.listRUMEvents({
+        filterQuery: query !== '*' ? query : undefined,
+        filterFrom: new Date(from * 1000),
+        filterTo: new Date(to * 1000),
+        sort: 'timestamp',
+        pageLimit: 1000,
+        ...(cursor ? { pageCursor: cursor } : {}),
+      })
+
+      if (!response.data || response.data.length === 0) {
+        break
+      }
+
+      allEvents.push(...response.data)
+
+      cursor = response.meta?.page?.after
+      if (!cursor) {
+        break
+      }
+    }
+
+    if (allEvents.length === 0) {
       throw new Error('No RUM events data returned')
     }
 
     // Extract session counts grouped by the specified dimension
     const sessions = new Map<string, Set<string>>()
 
-    for (const event of response.data) {
+    for (const event of allEvents) {
       if (!event.attributes?.attributes) {
         continue
       }
@@ -166,15 +206,33 @@ export const createRumToolHandlers = (
     // Build a query that focuses on view events with performance metrics
     const viewQuery = query !== '*' ? `@type:view ${query}` : '@type:view'
 
-    const response = await apiInstance.listRUMEvents({
-      filterQuery: viewQuery,
-      filterFrom: new Date(from * 1000),
-      filterTo: new Date(to * 1000),
-      sort: 'timestamp',
-      pageLimit: 2000,
-    })
+    // Paginate to collect all matching events
+    const allEvents: v2.RUMEvent[] = []
+    let cursor: string | undefined
 
-    if (response.data == null) {
+    while (true) {
+      const response = await apiInstance.listRUMEvents({
+        filterQuery: viewQuery,
+        filterFrom: new Date(from * 1000),
+        filterTo: new Date(to * 1000),
+        sort: 'timestamp',
+        pageLimit: 1000,
+        ...(cursor ? { pageCursor: cursor } : {}),
+      })
+
+      if (!response.data || response.data.length === 0) {
+        break
+      }
+
+      allEvents.push(...response.data)
+
+      cursor = response.meta?.page?.after
+      if (!cursor) {
+        break
+      }
+    }
+
+    if (allEvents.length === 0) {
       throw new Error('No RUM events data returned')
     }
 
@@ -187,7 +245,7 @@ export const createRumToolHandlers = (
       {} as Record<string, number[]>,
     )
 
-    for (const event of response.data) {
+    for (const event of allEvents) {
       if (!event.attributes?.attributes) {
         continue
       }
@@ -255,13 +313,30 @@ export const createRumToolHandlers = (
       request.params.arguments,
     )
 
-    const response = await apiInstance.listRUMEvents({
-      filterQuery: `@application.name:${applicationName} @session.id:${sessionId}`,
-      sort: 'timestamp',
-      pageLimit: 2000,
-    })
+    const allEvents: v2.RUMEvent[] = []
+    let cursor: string | undefined
 
-    if (response.data == null) {
+    while (true) {
+      const response = await apiInstance.listRUMEvents({
+        filterQuery: `@application.name:${applicationName} @session.id:${sessionId}`,
+        sort: 'timestamp',
+        pageLimit: 1000,
+        ...(cursor ? { pageCursor: cursor } : {}),
+      })
+
+      if (!response.data || response.data.length === 0) {
+        break
+      }
+
+      allEvents.push(...response.data)
+
+      cursor = response.meta?.page?.after
+      if (!cursor) {
+        break
+      }
+    }
+
+    if (allEvents.length === 0) {
       throw new Error('No RUM events data returned')
     }
 
@@ -269,7 +344,7 @@ export const createRumToolHandlers = (
       content: [
         {
           type: 'text',
-          text: `Waterfall data: ${JSON.stringify(response.data)}`,
+          text: `Waterfall data: ${JSON.stringify(allEvents)}`,
         },
       ],
     }

--- a/src/tools/traces/schema.ts
+++ b/src/tools/traces/schema.ts
@@ -8,7 +8,9 @@ export const ListTracesZodSchema = z.object({
     .number()
     .optional()
     .default(100)
-    .describe('Maximum number of traces to return'),
+    .describe(
+      'Maximum number of spans to return. Set 0 for unlimited (auto-paginates all results).',
+    ),
   sort: z
     .enum(['timestamp', '-timestamp'])
     .optional()

--- a/src/tools/traces/tool.ts
+++ b/src/tools/traces/tool.ts
@@ -31,38 +31,64 @@ export const createTracesToolHandlers = (
         operation,
       } = ListTracesZodSchema.parse(request.params.arguments)
 
-      const response = await apiInstance.listSpans({
-        body: {
-          data: {
-            attributes: {
-              filter: {
-                query: [
-                  query,
-                  ...(service ? [`service:${service}`] : []),
-                  ...(operation ? [`operation:${operation}`] : []),
-                ].join(' '),
-                from: new Date(from * 1000).toISOString(),
-                to: new Date(to * 1000).toISOString(),
-              },
-              sort: sort as 'timestamp' | '-timestamp',
-              page: { limit },
-            },
-            type: 'search_request',
-          },
-        },
-      })
+      const filterQuery = [
+        query,
+        ...(service ? [`service:${service}`] : []),
+        ...(operation ? [`operation:${operation}`] : []),
+      ].join(' ')
 
-      if (!response.data) {
+      const filterObj = {
+        query: filterQuery,
+        from: new Date(from * 1000).toISOString(),
+        to: new Date(to * 1000).toISOString(),
+      }
+
+      const unlimited = limit === 0
+      const allSpans: v2.Span[] = []
+      let cursor: string | undefined
+
+      while (unlimited || allSpans.length < limit) {
+        const pageLimit = unlimited
+          ? 1000
+          : Math.min(limit - allSpans.length, 1000)
+        const response = await apiInstance.listSpans({
+          body: {
+            data: {
+              attributes: {
+                filter: filterObj,
+                sort: sort as 'timestamp' | '-timestamp',
+                page: { limit: pageLimit, ...(cursor ? { cursor } : {}) },
+              },
+              type: 'search_request',
+            },
+          },
+        })
+
+        if (!response.data || response.data.length === 0) {
+          break
+        }
+
+        allSpans.push(...response.data)
+
+        cursor = response.meta?.page?.after
+        if (!cursor) {
+          break
+        }
+      }
+
+      if (allSpans.length === 0) {
         throw new Error('No traces data returned')
       }
+
+      const result = unlimited ? allSpans : allSpans.slice(0, limit)
 
       return {
         content: [
           {
             type: 'text',
             text: `Traces: ${JSON.stringify({
-              traces: response.data,
-              count: response.data.length,
+              traces: result,
+              count: result.length,
             })}`,
           },
         ],


### PR DESCRIPTION
## Summary

Two features in one branch:

### 1. Audit Log Tools (new)

Adds support for the Datadog Audit Logs API (`v2.AuditApi`) with two new tools:

- **`list_audit_logs`** — Simple filtering with query params (uses `listAuditLogs()`)
- **`search_audit_logs`** — Structured query with filter/page/sort (uses `searchAuditLogs()`)

### 2. Cursor-Based Pagination (fix)

All list/search tools previously returned only the first page of results, silently truncating
large result sets. Now every tool auto-paginates through Datadog's cursor-based pagination
(`meta.page.after` → `page.cursor`/`pageCursor`).

**Related:** [#35](https://github.com/winor30/mcp-server-datadog/pull/35) also addresses
pagination, but exposes the cursor to the caller for manual pagination. This PR auto-paginates
internally, which is better for MCP tool consumers (LLM agents) that would otherwise need N
sequential tool calls to get N pages.

**Tools updated with pagination:**

| Tool | API Style | Previously |
|------|-----------|------------|
| `list_traces` | POST body (`page.cursor`) | Returned max 100 spans |
| `get_logs` | POST body (`page.cursor`) | Returned max 100 logs |
| `get_all_services` | POST body (`page.cursor`) | Returned max 1000 logs |
| `list_audit_logs` | GET params (`pageCursor`) | Returned max 25 events |
| `search_audit_logs` | POST body (`page.cursor`) | Returned max 25 events |
| `get_rum_events` | GET params (`pageCursor`) | Returned max 100 events |
| `get_rum_grouped_event_count` | GET params (`pageCursor`) | Hardcoded 2000 |
| `get_rum_page_performance` | GET params (`pageCursor`) | Hardcoded 2000 |
| `get_rum_page_waterfall` | GET params (`pageCursor`) | Hardcoded 2000 |

**`limit=0` means unlimited** — auto-paginates all results. Default limits unchanged.

### Implementation

- Pagination loop pattern: `while` + cursor + break on empty/no-cursor
- Page size capped at 1000 per request (Datadog API max)
- `allResults.slice(0, limit)` ensures exact limit compliance
- Three RUM aggregation tools now paginate fully instead of hardcoding 2000

## Test plan

- [x] `npm run build` — compiles successfully
- [x] `npm test` — all existing tests pass
- [x] Manual: `list_traces` with `limit=0` on a 2,762-span trace — returned all spans
- [x] Manual: `get_logs` with `limit=0` on a broad query
- [x] Manual: `search_audit_logs` with pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)