### PR TITLE
Handle CLI metadata flags before startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,118 +7,167 @@
  * With a design built for scalability, future integrations with additional Datadog APIs are anticipated.
  */
 
-import { Server } from '@modelcontextprotocol/sdk/server/index.js'
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js'
 import { log, mcpDatadogVersion } from './utils/helper'
-import { INCIDENT_TOOLS, createIncidentToolHandlers } from './tools/incident'
-import { METRICS_TOOLS, createMetricsToolHandlers } from './tools/metrics'
-import { LOGS_TOOLS, createLogsToolHandlers } from './tools/logs'
-import { MONITORS_TOOLS, createMonitorsToolHandlers } from './tools/monitors'
-import {
-  DASHBOARDS_TOOLS,
-  createDashboardsToolHandlers,
-} from './tools/dashboards'
-import { TRACES_TOOLS, createTracesToolHandlers } from './tools/traces'
-import { HOSTS_TOOLS, createHostsToolHandlers } from './tools/hosts'
-import { ToolHandlers } from './utils/types'
-import { createDatadogConfig } from './utils/datadog'
-import { createDowntimesToolHandlers, DOWNTIMES_TOOLS } from './tools/downtimes'
-import { createRumToolHandlers, RUM_TOOLS } from './tools/rum'
-import { v2, v1 } from '@datadog/datadog-api-client'
+import type { ToolHandlers } from './utils/types'
 
-const server = new Server(
-  {
-    name: 'Datadog MCP Server',
-    version: mcpDatadogVersion,
-  },
-  {
-    capabilities: {
-      tools: {},
-    },
-  },
-)
+function printHelp() {
+  process.stdout.write(`mcp-server-datadog ${mcpDatadogVersion}
 
-server.onerror = (error) => {
-  log('error', `Server error: ${error.message}`, error.stack)
+Usage:
+  mcp-server-datadog [options]
+
+Options:
+  -h, --help      Show this help message
+  -v, --version   Show version number
+
+Environment:
+  DATADOG_API_KEY   Datadog API key required when starting the MCP server
+  DATADOG_APP_KEY   Datadog application key required when starting the MCP server
+`)
 }
 
-/**
- * Handler that retrieves the list of available tools in the mcp-server-datadog.
- * Currently, it provides incident management functionalities by integrating with Datadog's incident APIs.
- */
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return {
-    tools: [
-      ...INCIDENT_TOOLS,
-      ...METRICS_TOOLS,
-      ...LOGS_TOOLS,
-      ...MONITORS_TOOLS,
-      ...DASHBOARDS_TOOLS,
-      ...TRACES_TOOLS,
-      ...HOSTS_TOOLS,
-      ...DOWNTIMES_TOOLS,
-      ...RUM_TOOLS,
-    ],
+function handleMetadataFlag(args = process.argv.slice(2)) {
+  const [flag] = args
+
+  if (flag === '--version' || flag === '-v') {
+    process.stdout.write(`${mcpDatadogVersion}\n`)
+    return true
   }
-})
 
-if (!process.env.DATADOG_API_KEY || !process.env.DATADOG_APP_KEY) {
-  throw new Error('DATADOG_API_KEY and DATADOG_APP_KEY must be set')
-}
-
-const datadogConfig = createDatadogConfig({
-  apiKeyAuth: process.env.DATADOG_API_KEY,
-  appKeyAuth: process.env.DATADOG_APP_KEY,
-  site: process.env.DATADOG_SITE,
-  subdomain: process.env.DATADOG_SUBDOMAIN,
-})
-
-const TOOL_HANDLERS: ToolHandlers = {
-  ...createIncidentToolHandlers(new v2.IncidentsApi(datadogConfig)),
-  ...createMetricsToolHandlers(new v1.MetricsApi(datadogConfig)),
-  ...createLogsToolHandlers(new v2.LogsApi(datadogConfig)),
-  ...createMonitorsToolHandlers(new v1.MonitorsApi(datadogConfig)),
-  ...createDashboardsToolHandlers(new v1.DashboardsApi(datadogConfig)),
-  ...createTracesToolHandlers(new v2.SpansApi(datadogConfig)),
-  ...createHostsToolHandlers(new v1.HostsApi(datadogConfig)),
-  ...createDowntimesToolHandlers(new v1.DowntimesApi(datadogConfig)),
-  ...createRumToolHandlers(new v2.RUMApi(datadogConfig)),
-}
-/**
- * Handler for invoking Datadog-related tools in the mcp-server-datadog.
- * The TOOL_HANDLERS object contains various tools that interact with different Datadog APIs.
- * By specifying the tool name in the request, the LLM can select and utilize the required tool.
- */
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  try {
-    if (TOOL_HANDLERS[request.params.name]) {
-      return await TOOL_HANDLERS[request.params.name](request)
-    }
-    throw new Error('Unknown tool')
-  } catch (unknownError) {
-    const error =
-      unknownError instanceof Error
-        ? unknownError
-        : new Error(String(unknownError))
-    log(
-      'error',
-      `Request: ${request.params.name}, ${JSON.stringify(request.params.arguments)} failed`,
-      error.message,
-      error.stack,
-    )
-    throw error
+  if (flag === '--help' || flag === '-h') {
+    printHelp()
+    return true
   }
-})
+
+  return false
+}
+
+if (handleMetadataFlag()) {
+  process.exit(0)
+}
 
 /**
  * Initializes and starts the mcp-server-datadog using stdio transport,
  * which sends and receives data through standard input and output.
  */
 async function main() {
+  const [
+    { Server },
+    { StdioServerTransport },
+    { CallToolRequestSchema, ListToolsRequestSchema },
+    { INCIDENT_TOOLS, createIncidentToolHandlers },
+    { METRICS_TOOLS, createMetricsToolHandlers },
+    { LOGS_TOOLS, createLogsToolHandlers },
+    { MONITORS_TOOLS, createMonitorsToolHandlers },
+    { DASHBOARDS_TOOLS, createDashboardsToolHandlers },
+    { TRACES_TOOLS, createTracesToolHandlers },
+    { HOSTS_TOOLS, createHostsToolHandlers },
+    { createDatadogConfig },
+    { DOWNTIMES_TOOLS, createDowntimesToolHandlers },
+    { RUM_TOOLS, createRumToolHandlers },
+    { v2, v1 },
+  ] = await Promise.all([
+    import('@modelcontextprotocol/sdk/server/index.js'),
+    import('@modelcontextprotocol/sdk/server/stdio.js'),
+    import('@modelcontextprotocol/sdk/types.js'),
+    import('./tools/incident'),
+    import('./tools/metrics'),
+    import('./tools/logs'),
+    import('./tools/monitors'),
+    import('./tools/dashboards'),
+    import('./tools/traces'),
+    import('./tools/hosts'),
+    import('./utils/datadog'),
+    import('./tools/downtimes'),
+    import('./tools/rum'),
+    import('@datadog/datadog-api-client'),
+  ])
+
+  const server = new Server(
+    {
+      name: 'Datadog MCP Server',
+      version: mcpDatadogVersion,
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    },
+  )
+
+  server.onerror = (error) => {
+    log('error', `Server error: ${error.message}`, error.stack)
+  }
+
+  /**
+   * Handler that retrieves the list of available tools in the mcp-server-datadog.
+   * Currently, it provides incident management functionalities by integrating with Datadog's incident APIs.
+   */
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+      tools: [
+        ...INCIDENT_TOOLS,
+        ...METRICS_TOOLS,
+        ...LOGS_TOOLS,
+        ...MONITORS_TOOLS,
+        ...DASHBOARDS_TOOLS,
+        ...TRACES_TOOLS,
+        ...HOSTS_TOOLS,
+        ...DOWNTIMES_TOOLS,
+        ...RUM_TOOLS,
+      ],
+    }
+  })
+
+  if (!process.env.DATADOG_API_KEY || !process.env.DATADOG_APP_KEY) {
+    throw new Error('DATADOG_API_KEY and DATADOG_APP_KEY must be set')
+  }
+
+  const datadogConfig = createDatadogConfig({
+    apiKeyAuth: process.env.DATADOG_API_KEY,
+    appKeyAuth: process.env.DATADOG_APP_KEY,
+    site: process.env.DATADOG_SITE,
+    subdomain: process.env.DATADOG_SUBDOMAIN,
+  })
+
+  const TOOL_HANDLERS: ToolHandlers = {
+    ...createIncidentToolHandlers(new v2.IncidentsApi(datadogConfig)),
+    ...createMetricsToolHandlers(new v1.MetricsApi(datadogConfig)),
+    ...createLogsToolHandlers(new v2.LogsApi(datadogConfig)),
+    ...createMonitorsToolHandlers(new v1.MonitorsApi(datadogConfig)),
+    ...createDashboardsToolHandlers(new v1.DashboardsApi(datadogConfig)),
+    ...createTracesToolHandlers(new v2.SpansApi(datadogConfig)),
+    ...createHostsToolHandlers(new v1.HostsApi(datadogConfig)),
+    ...createDowntimesToolHandlers(new v1.DowntimesApi(datadogConfig)),
+    ...createRumToolHandlers(new v2.RUMApi(datadogConfig)),
+  }
+
+  /**
+   * Handler for invoking Datadog-related tools in the mcp-server-datadog.
+   * The TOOL_HANDLERS object contains various tools that interact with different Datadog APIs.
+   * By specifying the tool name in the request, the LLM can select and utilize the required tool.
+   */
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    try {
+      if (TOOL_HANDLERS[request.params.name]) {
+        return await TOOL_HANDLERS[request.params.name](request)
+      }
+      throw new Error('Unknown tool')
+    } catch (unknownError) {
+      const error =
+        unknownError instanceof Error
+          ? unknownError
+          : new Error(String(unknownError))
+      log(
+        'error',
+        `Request: ${request.params.name}, ${JSON.stringify(request.params.arguments)} failed`,
+        error.message,
+        error.stack,
+      )
+      throw error
+    }
+  })
+
   const transport = new StdioServerTransport()
   await server.connect(transport)
 }

--- a/tests/cli-metadata.test.ts
+++ b/tests/cli-metadata.test.ts
@@ -1,0 +1,50 @@
+import { spawnSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { version } from '../package.json'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const cliEntry = resolve(repoRoot, 'build/index.js')
+
+function runCli(flag: string) {
+  const env = { ...process.env }
+  delete env.DATADOG_API_KEY
+  delete env.DATADOG_APP_KEY
+
+  return spawnSync(process.execPath, [cliEntry, flag], {
+    cwd: repoRoot,
+    env,
+    encoding: 'utf8',
+    timeout: 3000,
+  })
+}
+
+describe('CLI metadata flags', () => {
+  beforeAll(() => {
+    const result = spawnSync('pnpm', ['build'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      timeout: 30000,
+    })
+
+    expect(result.status, result.stderr || result.stdout).toBe(0)
+  })
+
+  it('prints the package version without Datadog credentials', () => {
+    const result = runCli('--version')
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stdout.trim()).toBe(version)
+    expect(result.stderr).toBe('')
+  })
+
+  it('prints help without Datadog credentials', () => {
+    const result = runCli('--help')
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stdout).toContain('mcp-server-datadog')
+    expect(result.stdout).toContain('--version')
+    expect(result.stderr).toBe('')
+  })
+})


### PR DESCRIPTION
## What changed

This handles CLI metadata flags before loading the MCP server runtime path:

- `mcp-server-datadog --version` / `-v` prints the package version.
- `mcp-server-datadog --help` / `-h` prints a small usage message.
- Normal server startup still loads the Datadog/MCP runtime and still requires `DATADOG_API_KEY` plus `DATADOG_APP_KEY`.

## Why

The published `@winor30/mcp-server-datadog@1.7.0` package currently validates Datadog credentials before returning CLI metadata:

```sh
npm exec --yes --package=@winor30/mcp-server-datadog@1.7.0 -- mcp-server-datadog --version
npm exec --yes --package=@winor30/mcp-server-datadog@1.7.0 -- mcp-server-datadog --help
```

Both commands exit before metadata with:

```text
Error: DATADOG_API_KEY and DATADOG_APP_KEY must be set
```

That makes install smoke checks and agent setup probes require Datadog credentials just to read CLI metadata.

## Verification

- Red test first: `pnpm vitest run tests/cli-metadata.test.ts` failed before the implementation because metadata flags exited nonzero before producing metadata.
- `pnpm vitest run tests/cli-metadata.test.ts` -> 2 passed.
- `pnpm test` -> 13 test files / 103 tests passed.
- `pnpm build` -> passed.
- `pnpm exec eslint . --ext .ts,.js` -> passed.
- `pnpm exec prettier --check src/index.ts tests/cli-metadata.test.ts` -> passed.
- `git diff --check` -> passed.
- Local tarball smoke:
  - `npm exec --yes --package=/tmp/automoney-datadog-pack/winor30-mcp-server-datadog-1.7.0.tgz -- mcp-server-datadog --version` -> `1.7.0`
  - `npm exec --yes --package=/tmp/automoney-datadog-pack/winor30-mcp-server-datadog-1.7.0.tgz -- mcp-server-datadog --help` -> help text, exit 0
  - normal startup with no Datadog env still exits with `DATADOG_API_KEY and DATADOG_APP_KEY must be set`

Validation note: `pnpm exec tsc --noEmit` currently reports existing `LogsQueryFilter.storageTier` type errors in `src/tools/logs/tool.ts` at lines 77 and 124. This PR leaves those files untouched.
