### PR TITLE
Add package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@winor30/mcp-server-datadog",
   "version": "1.7.0",
   "description": "MCP server for interacting with Datadog API",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/winor30/mcp-server-datadog.git"


### PR DESCRIPTION
## Summary
- add the package-level `license` field using the repository's Apache-2.0 license
- keep runtime code, dependencies, entrypoints, and build output unchanged

## Verification
- `node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); if (p.name !== '@winor30/mcp-server-datadog' || p.license !== 'Apache-2.0') process.exit(1); console.log(JSON.stringify({name:p.name,version:p.version,license:p.license}))"`
- `npm pack --dry-run --json --ignore-scripts`
- `git diff --check`