### PR TITLE
Add license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@winor30/mcp-server-datadog",
   "version": "1.7.0",
   "description": "MCP server for interacting with Datadog API",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/winor30/mcp-server-datadog.git"


### PR DESCRIPTION
## Summary

Adds the package license metadata to `package.json`, matching the existing Apache-2.0 `LICENSE` file in the repository.

This leaves runtime code, dependencies, package exports, generated files, and version fields unchanged.

## Validation

- `node -e "const p=require('./package.json'); if (p.license !== 'Apache-2.0') throw new Error('license field missing or incorrect'); console.log(JSON.stringify({name:p.name,version:p.version,license:p.license}))"`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`