### PR TITLE
release 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winor30/mcp-server-datadog",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "MCP server for interacting with Datadog API",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Why

`v1.7.0` 以降、main に複数の変更がマージされており、未リリースの状態です。npm への公開に向けてバージョンを上げます。

## What

`package.json` の version を `1.7.0` → `1.8.0` に更新。

`v1.7.0` 以降に含まれる変更:

- feat: add DATADOG_STORAGE_TIER env support for logs tools (#49)
- build(deps): bump @modelcontextprotocol/sdk from 1.24.0 to 1.26.0 (#57)
- build(deps): bump brace-expansion from 1.1.11 to 1.1.13 (#70)
- build(deps): bump ajv from 6.12.6 to 6.14.0 (#59)
- build(deps): bump vite from 6.3.5 to 8.0.5 (#72)

機能追加 (`feat`) を含むため minor バンプ。

マージ後、main で `v1.8.0` タグを push すると `publish.yml` が npm 公開を行います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)